### PR TITLE
Refactor the import/export in the compiler code (v2)

### DIFF
--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -6,8 +6,8 @@
 
 import StringIO
 
-from visitor import Visitor
-from utils import *
+import visitor
+import utils
 
 
 class AstNode(object):
@@ -737,16 +737,16 @@ class AstStringLiteral(AstLiteral):
         self.value = value
 
     def __repr__(self):
-        return "AstStringLiteral(%s)" % encodeString(self.value)
+        return "AstStringLiteral(%s)" % utils.encodeString(self.value)
 
     def tag(self):
         return "StringLiteral"
 
     def data(self):
-        return encodeString(self.value)
+        return utils.encodeString(self.value)
 
 
-class AstNodeVisitor(Visitor):
+class AstNodeVisitor(visitor.Visitor):
     def visitChildren(self, node):
         for child in node.children():
             if child is not None:
@@ -773,7 +773,7 @@ class AstPrinter(AstNodeVisitor):
 
 class AstEnumerator(AstNodeVisitor):
     def __init__(self):
-        self.counter = Counter()
+        self.counter = utils.Counter()
 
     def visitDefault(self, node):
         node.id = self.counter()

--- a/compiler/builtins.py
+++ b/compiler/builtins.py
@@ -11,6 +11,7 @@ import yaml
 import ir
 import ir_types
 
+import bytecode
 
 def registerBuiltins(bind):
     _initialize()
@@ -105,7 +106,7 @@ def _initialize():
                                [],
                                map(buildType, functionData["parameterTypes"]),
                                [], [], frozenset())
-        function.id = getattr(ir_types,functionData["id"])
+        function.id = getattr(bytecode,functionData["id"])
         if "insts" in functionData:
             function.insts = functionData["insts"]
         return function
@@ -126,7 +127,7 @@ def _initialize():
 
     def defineClass(classData):
         clas = _builtinClassNameMap[classData["name"]]
-        clas.id = getattr(ir_types,classData["id"])
+        clas.id = getattr(bytecode,classData["id"])
         if not classData["isPrimitive"]:
             if classData["supertype"] is not None:
                 superclass = _builtinClassNameMap[classData["supertype"]]

--- a/compiler/builtins.py
+++ b/compiler/builtins.py
@@ -105,7 +105,7 @@ def _initialize():
                                [],
                                map(buildType, functionData["parameterTypes"]),
                                [], [], frozenset())
-        function.id = getattr(ir,functionData["id"])
+        function.id = getattr(ir_types,functionData["id"])
         if "insts" in functionData:
             function.insts = functionData["insts"]
         return function
@@ -126,7 +126,7 @@ def _initialize():
 
     def defineClass(classData):
         clas = _builtinClassNameMap[classData["name"]]
-        clas.id = getattr(ir,classData["id"])
+        clas.id = getattr(ir_types,classData["id"])
         if not classData["isPrimitive"]:
             if classData["supertype"] is not None:
                 superclass = _builtinClassNameMap[classData["supertype"]]

--- a/compiler/builtins.py
+++ b/compiler/builtins.py
@@ -8,11 +8,8 @@ import os.path
 import re
 import yaml
 
-from bytecode import *
-from data import *
-from ir import *
+import ir
 import ir_types
-from utils import *
 
 
 def registerBuiltins(bind):
@@ -103,12 +100,12 @@ def _initialize():
 
     def buildFunction(functionData):
         name = functionData.get("name", "$constructor")
-        function = Function(name,
-                            buildType(functionData["returnType"]),
-                            [],
-                            map(buildType, functionData["parameterTypes"]),
-                            [], [], frozenset())
-        function.id = globals()[functionData["id"]]
+        function = ir.Function(name,
+                               buildType(functionData["returnType"]),
+                               [],
+                               map(buildType, functionData["parameterTypes"]),
+                               [], [], frozenset())
+        function.id = getattr(ir,functionData["id"])
         if "insts" in functionData:
             function.insts = functionData["insts"]
         return function
@@ -121,15 +118,15 @@ def _initialize():
     def buildField(fieldData):
         name = fieldData["name"]
         ty = buildType(fieldData["type"])
-        return Field(name, ty, frozenset())
+        return ir.Field(name, ty, frozenset())
 
     def declareClass(classData):
-        clas = Class(classData["name"], [], None, None, None, None, None, frozenset())
+        clas = ir.Class(classData["name"], [], None, None, None, None, None, frozenset())
         _builtinClassNameMap[classData["name"]] = clas
 
     def defineClass(classData):
         clas = _builtinClassNameMap[classData["name"]]
-        clas.id = globals()[classData["id"]]
+        clas.id = getattr(ir,classData["id"])
         if not classData["isPrimitive"]:
             if classData["supertype"] is not None:
                 superclass = _builtinClassNameMap[classData["supertype"]]
@@ -174,3 +171,8 @@ def _initialize():
         defineClass(ty)
     for fn in functions:
         defineFunction(fn)
+
+__all__ = ["registerBuiltins", "getRootClass", "getNothingClass",
+           "getExceptionClass", "getTypeClass", "getStringClass",
+           "getBuiltinClasses", "getBuiltinClassFromType",
+           "getBuiltinFunctions", "isBuiltinId"]

--- a/compiler/bytecode.py
+++ b/compiler/bytecode.py
@@ -8,11 +8,11 @@ from collections import namedtuple
 import os.path
 import yaml
 
-from utils import *
+import utils
 
 InstInfo = namedtuple("InstInfo", ["name", "opcode", "operandCount", "isTerminator"])
 
-_c = Counter()
+_c = utils.Counter()
 instInfoByName = {}
 instInfoByCode = []
 
@@ -35,8 +35,8 @@ WORDSIZE = 8
 
 # Builtin definitions are accessible to the compiler, but are not included in packages. They
 # are referenced by negative ids. The VM implements these.
-_nextClassId = Counter(-1, -1)
-_nextFunctionId = Counter(-1, -1)
+_nextClassId = utils.Counter(-1, -1)
+_nextFunctionId = utils.Counter(-1, -1)
 
 _builtinsPath = os.path.join(os.path.dirname(__file__), "..", "common", "builtins.yaml")
 with open(_builtinsPath) as _builtinsFile:

--- a/compiler/combinators.py
+++ b/compiler/combinators.py
@@ -4,7 +4,7 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from location import *
+from location import Location
 
 
 class Reader(object):
@@ -297,3 +297,7 @@ def untangle(parsed):
         for element in parsed:
             elements.extend(untangle(element))
         return elements
+
+__all__ = ["Reader", "Rep", "Rep1", "RepSep", "Rep1Sep", "Phrase", "Tag",
+           "Reserved", "Opt", "Lazy", "LeftRec", "Commit", "If", "FailValue",
+           "untangle"]

--- a/compiler/compile_info.py
+++ b/compiler/compile_info.py
@@ -8,6 +8,7 @@ import ast
 import builtins
 import data
 import ir
+import ir_types
 
 
 BUILTIN_SCOPE_ID = -1
@@ -286,13 +287,13 @@ def getAllArgumentTypes(irFunction, receiverType, typeArgs, argTypes):
     containing the full list of type arguments and argument types (including the receiver).
     If the function is not compatible, returns None."""
     if receiverType is not None:
-        if isinstance(receiverType, ir.ObjectType):
+        if isinstance(receiverType, ir_types.ObjectType):
             receiverType = receiverType.substituteForBaseClass(irFunction.clas)
         implicitTypeArgs = list(receiverType.getTypeArguments())
         allArgTypes = [receiverType] + argTypes
     else:
         implicitTypeParams = getImplicitTypeParameters(irFunction)
-        implicitTypeArgs = [ir.VariableType(t) for t in implicitTypeParams]
+        implicitTypeArgs = [ir_types.VariableType(t) for t in implicitTypeParams]
         allArgTypes = argTypes
     allTypeArgs = implicitTypeArgs + typeArgs
 

--- a/compiler/compile_info.py
+++ b/compiler/compile_info.py
@@ -4,10 +4,9 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from ast import *
-from builtins import *
+import ast
 import builtins
-from data import *
+import data
 import ir
 
 
@@ -50,7 +49,7 @@ class CompileInfo(object):
     def _key(self, k):
         if isinstance(k, int):
             return k
-        elif isinstance(k, AstNode):
+        elif isinstance(k, ast.AstNode):
             return k.id
         elif hasattr(k, "astDefn"):
             return k.astDefn.id
@@ -81,7 +80,7 @@ for _elemName, _dictName in _dictNames:
     _addDictMethods(_elemName, _dictName)
 
 
-class ContextInfo(Data):
+class ContextInfo(data.Data):
     """Created for every AST node which creates a scope.
 
     This includes classes and functions, but it also includes block expressions, lambda
@@ -107,7 +106,7 @@ class ContextInfo(Data):
         return "ContextInfo(%d, %s)" % (self.id, irContextClassStr)
 
 
-class ClosureInfo(Data):
+class ClosureInfo(data.Data):
     """Created for nodes which create a scope and use something defined in an outer scope.
 
     The use may be in an inner scope. Note that ClosureInfo is not created for local scopes."""
@@ -151,7 +150,7 @@ NOT_HERITABLE = -1
 # DefnInfo is available for every AST node which defines something, such as classes, functions,
 # parameters, and individual variables. This is used to map AST definitions to their
 # IR definition stubs.
-class DefnInfo(Data):
+class DefnInfo(data.Data):
     """Created for every AST node which defines something.
 
     This includes classes, functions, and individual variables. This is used to map AST
@@ -204,7 +203,7 @@ USE_AS_PROPERTY = "USE_AS_PROPERTY"
 USE_AS_CONSTRUCTOR = "USE_AS_CONSTRUCTOR"
 
 
-class UseInfo(Data):
+class UseInfo(data.Data):
     """Created for every AST node which refers to a definition using a symbol."""
 
     propertyNames = [
@@ -229,7 +228,7 @@ class UseInfo(Data):
                not useScope.isLocalWithin(defnScope)
 
 
-class ClassInfo(Data):
+class ClassInfo(data.Data):
     """Defined for each class. Keeps track of superclass."""
 
     propertyNames = [
@@ -248,7 +247,7 @@ class ClassInfo(Data):
         return "ClassInfo(%s, %s)" % (irDefnStr, superclassInfoStr)
 
 
-class CallInfo(Data):
+class CallInfo(data.Data):
     """Defined at each call site during type/use analysis. Tracks information needed for the
     compiler to generate the call."""
 
@@ -303,7 +302,7 @@ def getAllArgumentTypes(irFunction, receiverType, typeArgs, argTypes):
         return None
 
 
-class InfoPrinter(AstPrinter):
+class InfoPrinter(ast.AstPrinter):
     def __init__(self, out, info):
         super(InfoPrinter, self).__init__(out)
         self.info = info
@@ -329,3 +328,12 @@ class InfoPrinter(AstPrinter):
 
         for s in infoStrs:
             self.out.write("%s- %s\n" % (indent, s))
+
+
+__all__ = [ "CompileInfo", "ContextInfo", "ClosureInfo", "DefnInfo",
+            "ClassInfo", "UseInfo", "getAllArgumentTypes",
+            "GLOBAL_SCOPE_ID", "BUILTIN_SCOPE_ID",
+            "USE_AS_VALUE", "USE_AS_TYPE", "USE_AS_PROPERTY", "USE_AS_CONSTRUCTOR",
+            "CONTEXT_CONSTRUCTOR_HINT", "CLOSURE_CONSTRUCTOR_HINT",
+            "getExplicitTypeParameters", "getImplicitTypeParameters",
+            "NOT_HERITABLE"]

--- a/compiler/compiler
+++ b/compiler/compiler
@@ -18,6 +18,8 @@ from scope_analysis import *
 from type_analysis import *
 from compiler import compile
 from serialize import serialize
+from compile_info import CompileInfo
+from errors import CompileException
 
 sys.setrecursionlimit(10000)
 

--- a/compiler/compiler
+++ b/compiler/compiler
@@ -12,7 +12,7 @@ import os.path
 import argparse
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from scope_analysis import *
 from type_analysis import *

--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -998,3 +998,5 @@ class PropertyLValue(LValue):
 
     def evaluate(self):
         self.compiler.loadField(self.field)
+
+__all__ = ["compile"]

--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -6,14 +6,16 @@
 
 from functools import partial
 
-from ast import *
-from bytecode import *
-from ir import *
-from ir_types import *
+import ast
+from bytecode import W8, W16, W32, W64, BUILTIN_TYPE_CLASS_ID, BUILTIN_TYPE_CTOR_ID, instInfoByCode
+from ir import Global, Variable, Field, Function, Class, LOCAL
+from ir_types import UnitType, ClassType, VariableType, NULLABLE_TYPE_FLAG
 import ir_instructions
-from ir_instructions import *
-from scope_analysis import *
-from utils import *
+from compile_info import CONTEXT_CONSTRUCTOR_HINT, CLOSURE_CONSTRUCTOR_HINT, PACKAGE_INITIALIZER_HINT, DefnInfo
+from flags import ABSTRACT, STATIC, LET
+from errors import SemanticException
+from builtins import getTypeClass, getExceptionClass, getRootClass
+from utils import Counter, COMPILE_FOR_EFFECT, COMPILE_FOR_VALUE, COMPILE_FOR_UNINITIALIZED, COMPILE_FOR_MATCH
 
 def compile(info):
     for clas in info.package.classes:
@@ -33,7 +35,7 @@ def assignFieldIndices(clas, info):
         field.index = index
 
 
-class CompileVisitor(AstNodeVisitor):
+class CompileVisitor(ast.AstNodeVisitor):
     def __init__(self, function, info):
         self.function = function
         self.astDefn = function.astDefn if hasattr(function, "astDefn") else None
@@ -53,20 +55,20 @@ class CompileVisitor(AstNodeVisitor):
             return
 
         # Get the body of the function as a list of statements. Also parameters.
-        if isinstance(self.astDefn, AstFunctionDefinition):
+        if isinstance(self.astDefn, ast.AstFunctionDefinition):
             if self.astDefn.body is None:
                 assert ABSTRACT in self.function.flags
                 return
             parameters = self.astDefn.parameters
-            if isinstance(self.astDefn.body, AstBlockExpression):
+            if isinstance(self.astDefn.body, ast.AstBlockExpression):
                 statements = self.astDefn.body.statements
             else:
                 statements = [self.astDefn.body]
-        elif isinstance(self.astDefn, AstClassDefinition):
+        elif isinstance(self.astDefn, ast.AstClassDefinition):
             parameters = None
             statements = self.astDefn.members
         else:
-            assert isinstance(self.astDefn, AstPrimaryConstructorDefinition)
+            assert isinstance(self.astDefn, ast.AstPrimaryConstructorDefinition)
             parameters = self.astDefn.parameters
             statements = []
 
@@ -79,13 +81,13 @@ class CompileVisitor(AstNodeVisitor):
         superCtorCalled = False
         if self.function.isConstructor() and \
            len(statements) > 0 and \
-           isinstance(statements[0], AstCallExpression):
-            if isinstance(statements[0].callee, AstThisExpression):
+           isinstance(statements[0], ast.AstCallExpression):
+            if isinstance(statements[0].callee, ast.AstThisExpression):
                 self.visitCallThisExpression(statements[0], COMPILE_FOR_EFFECT)
                 altCtorCalled = True
                 superCtorCalled = True
                 del statements[0]
-            elif isinstance(statements[0].callee, AstSuperExpression):
+            elif isinstance(statements[0].callee, ast.AstSuperExpression):
                 self.visitCallSuperExpression(statements[0], COMPILE_FOR_EFFECT)
                 superCtorCalled = True
                 del statements[0]
@@ -101,7 +103,7 @@ class CompileVisitor(AstNodeVisitor):
             if len(defaultSuperCtors) == 0:
                 raise SemanticException(self.function.clas.getLocation(),
                                         "no default constructor in superclass %s" %
-                                          superclass.name)
+                                        superclass.name)
             self.loadThis()
             self.buildStaticTypeArguments(supertype.typeArguments)
             self.callg(defaultSuperCtors[0].id)
@@ -111,7 +113,7 @@ class CompileVisitor(AstNodeVisitor):
         # initializer. In this case, unpacking the parameters means storing them into the
         # object. The initializer may need to access them.
         if self.function.isConstructor() and \
-           isinstance(self.function.astDefn, AstPrimaryConstructorDefinition):
+           isinstance(self.function.astDefn, ast.AstPrimaryConstructorDefinition):
             self.unpackParameters(parameters)
             parameters = None
 
@@ -159,7 +161,7 @@ class CompileVisitor(AstNodeVisitor):
         elif self.compileHint is PACKAGE_INITIALIZER_HINT:
             # This function initializes all the global variables.
             for defn in self.info.ast.definitions:
-                if isinstance(defn, AstVariableDefinition):
+                if isinstance(defn, ast.AstVariableDefinition):
                     self.visit(defn, COMPILE_FOR_EFFECT)
             self.unit()
             self.ret()
@@ -219,7 +221,7 @@ class CompileVisitor(AstNodeVisitor):
 
     def visitAstLiteralExpression(self, expr, mode):
         lit = expr.literal
-        if isinstance(lit, AstIntegerLiteral):
+        if isinstance(lit, ast.AstIntegerLiteral):
             if lit.width == 8:
                 self.i8(lit.value)
             elif lit.width == 16:
@@ -229,21 +231,21 @@ class CompileVisitor(AstNodeVisitor):
             else:
                 assert lit.width == 64
                 self.i64(lit.value)
-        elif isinstance(lit, AstFloatLiteral):
+        elif isinstance(lit, ast.AstFloatLiteral):
             if lit.width == 32:
                 self.f32(lit.value)
             else:
                 assert lit.width == 64
                 self.f64(lit.value)
-        elif isinstance(lit, AstStringLiteral):
+        elif isinstance(lit, ast.AstStringLiteral):
             id = self.info.package.findOrAddString(lit.value)
             self.string(id)
-        elif isinstance(lit, AstBooleanLiteral):
+        elif isinstance(lit, ast.AstBooleanLiteral):
             if lit.value:
                 self.true()
             else:
                 self.false()
-        elif isinstance(lit, AstNullLiteral):
+        elif isinstance(lit, ast.AstNullLiteral):
             self.null()
         else:
             raise NotImplementedError
@@ -296,9 +298,9 @@ class CompileVisitor(AstNodeVisitor):
     def visitAstCallExpression(self, expr, mode):
         useInfo = self.info.getUseInfo(expr)
         callInfo = self.info.getCallInfo(expr) if self.info.hasCallInfo(expr) else None
-        if isinstance(expr.callee, AstVariableExpression):
+        if isinstance(expr.callee, ast.AstVariableExpression):
             self.buildCall(useInfo, callInfo, None, expr.typeArguments, expr.arguments, mode)
-        elif isinstance(expr.callee, AstPropertyExpression):
+        elif isinstance(expr.callee, ast.AstPropertyExpression):
             self.buildCall(useInfo, callInfo, expr.callee.receiver,
                            expr.typeArguments, expr.arguments, mode)
         else:
@@ -531,8 +533,8 @@ class CompileVisitor(AstNodeVisitor):
 
     def newBlock(self):
         if self.unreachable:
-            return BasicBlock(-1, [])
-        block = BasicBlock(self.nextBlockId(), [])
+            return ir_instructions.BasicBlock(-1, [])
+        block = ir_instructions.BasicBlock(self.nextBlockId(), [])
         self.blocks.append(block)
         return block
 
@@ -546,12 +548,12 @@ class CompileVisitor(AstNodeVisitor):
         irDefn = useInfo.defnInfo.irDefn
         if LET in irDefn.flags:
             raise SemanticException(expr.location, "left side of assignment is constant")
-        if isinstance(expr, AstVariableExpression) and \
+        if isinstance(expr, ast.AstVariableExpression) and \
            (isinstance(irDefn, Variable) or \
             isinstance(irDefn, Field) or \
             isinstance(irDefn, Global)):
             return VarLValue(expr, self, useInfo)
-        elif isinstance(expr, AstPropertyExpression) and isinstance(irDefn, Field):
+        elif isinstance(expr, ast.AstPropertyExpression) and isinstance(irDefn, Field):
             self.visit(expr.receiver, COMPILE_FOR_VALUE)
             return PropertyLValue(expr, self, useInfo)
         else:
@@ -573,7 +575,7 @@ class CompileVisitor(AstNodeVisitor):
             implicitParamCount = 0
         if parameters is not None:
             for index, param in enumerate(parameters):
-                if isinstance(param.pattern, AstVariablePattern):
+                if isinstance(param.pattern, ast.AstVariablePattern):
                     defnInfo = self.info.getDefnInfo(param.pattern)
                     if isinstance(defnInfo.irDefn, Variable):
                        defnInfo.irDefn.index = index + implicitParamCount
@@ -585,7 +587,7 @@ class CompileVisitor(AstNodeVisitor):
 
     def unpackParameter(self, param, index):
         paramType = self.info.getType(param)
-        if isinstance(param.pattern, AstVariablePattern):
+        if isinstance(param.pattern, ast.AstVariablePattern):
             defnInfo = self.info.getDefnInfo(param.pattern)
             if isinstance(defnInfo.irDefn, Variable):
                 defnInfo.irDefn.index = index
@@ -600,7 +602,7 @@ class CompileVisitor(AstNodeVisitor):
         # Create a context if needed.
         if scopeId is not None and \
            not (self.astDefn.id == scopeId and
-                isinstance(self.astDefn, AstClassDefinition)) and \
+                isinstance(self.astDefn, ast.AstClassDefinition)) and \
            self.info.hasContextInfo(scopeId):
             contextInfo = self.info.getContextInfo(scopeId)
             if contextInfo.irContextClass is not None:
@@ -621,7 +623,7 @@ class CompileVisitor(AstNodeVisitor):
         # Compile the last statement. If this is an expression, the result is the result of the
         # whole block. Otherwise, we need to push the unit value.
         if len(statements) > 0:
-            if isinstance(statements[-1], AstExpression):
+            if isinstance(statements[-1], ast.AstExpression):
                 self.visit(statements[-1], mode)
                 needUnit = False
             else:
@@ -680,30 +682,30 @@ class CompileVisitor(AstNodeVisitor):
         ty = field.type
         if ty.isObject():
             if ty.isNullable():
-                inst = ldp
+                inst = ir_instructions.ldp
             else:
-                inst = ldpc
+                inst = ir_instructions.ldpc
         elif ty.width == W8:
-            inst = ld8
+            inst = ir_instructions.ld8
         elif ty.width == W16:
-            inst = ld16
+            inst = ir_instructions.ld16
         elif ty.width == W32:
-            inst = ld32
+            inst = ir_instructions.ld32
         elif ty.width == W64:
-            inst = ld64
+            inst = ir_instructions.ld64
         self.add(inst(field.index))
 
     def storeField(self, field):
         if field.type.isObject():
-            inst = stp
+            inst = ir_instructions.stp
         elif field.type.width == W8:
-            inst = st8
+            inst = ir_instructions.st8
         elif field.type.width == W16:
-            inst = st16
+            inst = ir_instructions.st16
         elif field.type.width == W32:
-            inst = st32
+            inst = ir_instructions.st32
         elif field.type.width == W64:
-            inst = st64
+            inst = ir_instructions.st64
         self.add(inst(field.index))
 
     def loadThis(self):
@@ -728,7 +730,7 @@ class CompileVisitor(AstNodeVisitor):
     def buildDeclarations(self, statements):
         # Handle any non-variable definitions
         for stmt in statements:
-            if isinstance(stmt, AstFunctionDefinition):
+            if isinstance(stmt, ast.AstFunctionDefinition):
                 closureInfo = self.info.getClosureInfo(stmt)
                 closureClass = closureInfo.irClosureClass
                 if closureClass is None or \
@@ -748,7 +750,7 @@ class CompileVisitor(AstNodeVisitor):
                 self.callg(closureCtor.id)
                 self.drop()
                 self.storeVariable(closureInfo.irClosureVar)
-            elif isinstance(stmt, AstClassDefinition):
+            elif isinstance(stmt, ast.AstClassDefinition):
                 raise NotImplementedError
 
     def buildCallSimpleMethod(self, method, mode):
@@ -818,11 +820,11 @@ class CompileVisitor(AstNodeVisitor):
                     if receiver.onStack():
                         self.dup()
                     receiver.evaluate()
-                elif isinstance(receiver, AstSuperExpression):
+                elif isinstance(receiver, ast.AstSuperExpression):
                     # Special case: load `super` as `this`
                     self.visitAstThisExpression(receiver, COMPILE_FOR_VALUE)
                 else:
-                    assert isinstance(receiver, AstExpression)
+                    assert isinstance(receiver, ast.AstExpression)
                     self.visit(receiver, COMPILE_FOR_VALUE)
 
             # Compile the arguments and call the method.
@@ -830,7 +832,7 @@ class CompileVisitor(AstNodeVisitor):
             compileTypeArgs()
             if hasattr(irDefn, "insts"):
                 for instName in irDefn.insts:
-                    inst = globals()[instName]
+                    inst = getattr(ir_instructions,instName)
                     self.add(inst())
             elif irDefn.isFinal():
                 # Calls to final methods can be made directly. This includes constructors and
@@ -886,7 +888,7 @@ class CompileVisitor(AstNodeVisitor):
             raise NotImplementedError
 
     def getScopeAstDefn(self):
-        if isinstance(self.astDefn, AstPrimaryConstructorDefinition):
+        if isinstance(self.astDefn, ast.AstPrimaryConstructorDefinition):
             return self.function.clas.astDefn
         else:
             return self.astDefn

--- a/compiler/data.py
+++ b/compiler/data.py
@@ -4,7 +4,7 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from utils import *
+import utils
 
 class Data(object):
     @staticmethod
@@ -37,4 +37,6 @@ class Data(object):
         return not (self == other)
 
     def __hash__(self):
-        return hashList(getattr(self, name) for name in self.propertyNames)
+        return utils.hashList(getattr(self, name) for name in self.propertyNames)
+
+__all__ = ["Data"]

--- a/compiler/flags.py
+++ b/compiler/flags.py
@@ -47,3 +47,6 @@ def _initialize():
     _flagGroups.append(frozenset([PUBLIC, PROTECTED, PRIVATE]))
     _flagGroups.append(frozenset([COVARIANT, CONTRAVARIANT]))
 _initialize()
+
+__all__ = ["getFlagByName", "checkFlagConflicts", "flagSetToFlagBits"] + \
+        _flagNames.values()

--- a/compiler/graph.py
+++ b/compiler/graph.py
@@ -160,3 +160,5 @@ class Graph(object):
     def isCyclic(self):
         sccGraph = self.stronglyConnectedComponents()
         return len(sccGraph.vertices()) < len(self.vertices())
+
+__all__ = ["Graph"]

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -9,6 +9,7 @@ import compile_info
 import data
 import flags
 import ir_types
+import bytecode
 
 import StringIO
 
@@ -212,7 +213,7 @@ class Class(IrDefinition):
 
     def superclasses(self):
         """Returns a generator of superclasses in depth-first order, including this class."""
-        assert self.id is not ir_types.BUILTIN_NOTHING_CLASS_ID
+        assert self.id is not bytecode.BUILTIN_NOTHING_CLASS_ID
         yield self
         clas = self
         while len(clas.supertypes) > 0:

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -213,7 +213,7 @@ class Class(IrDefinition):
 
     def superclasses(self):
         """Returns a generator of superclasses in depth-first order, including this class."""
-        assert self.id is not builtins.BUILTIN_NOTHING_CLASS_ID
+        assert self.id is not BUILTIN_NOTHING_CLASS_ID
         yield self
         clas = self
         while len(clas.supertypes) > 0:

--- a/compiler/ir_instructions.py
+++ b/compiler/ir_instructions.py
@@ -69,3 +69,5 @@ for info in bytecode.instInfoByCode:
     globals()[info.name] = type(info.name,
                                 (Instruction,),
                                 {"info": info})
+
+__all__ = ["BasicBlock", "Instruction"] + [info.name for info in bytecode.instInfoByCode]

--- a/compiler/ir_instructions.py
+++ b/compiler/ir_instructions.py
@@ -4,11 +4,11 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from data import *
-from bytecode import *
-from ir_types import *
+import data
+import bytecode
+import utils
 
-BasicBlockBase = Data.makeClass("BasicBlockBase", ("id", "instructions"))
+BasicBlockBase = data.Data.makeClass("BasicBlockBase", ("id", "instructions"))
 class BasicBlock(BasicBlockBase):
     def __init__(self, id, instructions):
         super(BasicBlock, self).__init__(id, instructions)
@@ -24,6 +24,7 @@ class Instruction(object):
 
     @staticmethod
     def forOpcode(opcode, *operands):
+        #TODO: this code is unreachable and seems broken.
         info = getInstInfoForOpcode(opcode)
         return globals()[info.name](*operands)
 
@@ -61,10 +62,10 @@ class Instruction(object):
         return not (self == other)
 
     def __hash__(self):
-        return hashList([self.info.opcode] + self.operands)
+        return utils.hashList([self.info.opcode] + self.operands)
 
 
-for info in instInfoByCode:
+for info in bytecode.instInfoByCode:
     globals()[info.name] = type(info.name,
                                 (Instruction,),
                                 {"info": info})

--- a/compiler/ir_types.py
+++ b/compiler/ir_types.py
@@ -7,16 +7,16 @@
 import copy
 
 import builtins
-from bytecode import *
-from data import *
-from errors import *
-from flags import *
-from ir_values import *
+import bytecode
+import data
+import errors
+import flags
+import ir_values
 import utils
 
 NULLABLE_TYPE_FLAG = "nullable"
 
-class Type(Data):
+class Type(data.Data):
     propertyNames = ("flags",)
 
     def __init__(self, flags=None):
@@ -82,10 +82,10 @@ class Type(Data):
             otherTypeArgs = ty.substituteForBaseClass(commonBase).typeArguments
             if selfTypeArgs != otherTypeArgs:
                 # TODO: support co/contra-variance
-                raise TypeException(loc, "could not combine; incompatible type args")
+                raise errors.TypeException(loc, "could not combine; incompatible type args")
             return ClassType(commonBase, selfTypeArgs, commonFlags)
         else:
-            raise TypeException(loc, "could not combine")
+            raise errors.TypeException(loc, "could not combine")
 
     def combineFlags(self, other):
         return self.flags.union(other.flags)
@@ -142,7 +142,7 @@ class SimpleType(Type):
         return False
 
     def size(self):
-        widthSizes = { W8: 1, W16: 2, W32: 4, W64: 8 }
+        widthSizes = { bytecode.W8: 1, bytecode.W16: 2, bytecode.W32: 4, bytecode.W64: 8 }
         return widthSizes[self.width]
 
     def defaultValue(self):
@@ -157,14 +157,14 @@ class SimpleType(Type):
 
 
 NoType = SimpleType("_", None)
-UnitType = SimpleType("unit", W8, UnitValue())
-I8Type = SimpleType("i8", W8, I8Value(0))
-I16Type = SimpleType("i16", W16, I16Value(0))
-I32Type = SimpleType("i32", W32, I32Value(0))
-I64Type = SimpleType("i64", W64, I64Value(0))
-F32Type = SimpleType("f32", W32, F32Value(0.))
-F64Type = SimpleType("f64", W64, F64Value(0.))
-BooleanType = SimpleType("boolean", W8, BooleanValue(False))
+UnitType = SimpleType("unit", bytecode.W8, ir_values.UnitValue())
+I8Type = SimpleType("i8", bytecode.W8, ir_values.I8Value(0))
+I16Type = SimpleType("i16", bytecode.W16, ir_values.I16Value(0))
+I32Type = SimpleType("i32", bytecode.W32, ir_values.I32Value(0))
+I64Type = SimpleType("i64", bytecode.W64, ir_values.I64Value(0))
+F32Type = SimpleType("f32", bytecode.W32, ir_values.F32Value(0.))
+F64Type = SimpleType("f64", bytecode.W64, ir_values.F64Value(0.))
+BooleanType = SimpleType("boolean", bytecode.W8, ir_values.BooleanValue(False))
 
 
 class ObjectType(Type):
@@ -178,7 +178,7 @@ class ObjectType(Type):
         return True
 
     def size(self):
-        return WORDSIZE
+        return bytecode.WORDSIZE
 
     def substituteForBaseClass(self, base):
         """Returns a base type of the corresponding class with type arguments substituted
@@ -190,7 +190,7 @@ class ObjectType(Type):
 
 class ClassType(ObjectType):
     propertyNames = Type.propertyNames + ("clas", "typeArguments")
-    width = WORD
+    width = bytecode.WORD
 
     def __init__(self, clas, typeArguments=(), flags=None):
         super(ClassType, self).__init__(flags)
@@ -240,9 +240,9 @@ class ClassType(ObjectType):
 
         def checkArg(a, b, param):
             argVariance = changeVariance(variance, param.variance())
-            if argVariance is COVARIANT:
+            if argVariance is flags.COVARIANT:
                 return a.isSubtypeOfWithVariance(b, argVariance)
-            elif argVariance is CONTRAVARIANT:
+            elif argVariance is flags.CONTRAVARIANT:
                 return b.isSubtypeOfWithVariance(a, argVariance)
             else:
                 assert argVariance is INVARIANT
@@ -276,7 +276,7 @@ class ClassType(ObjectType):
 
 class VariableType(ObjectType):
     propertyNames = Type.propertyNames + ("typeParameter",)
-    width = WORD
+    width = bytecode.WORD
 
     def __init__(self, typeParameter):
         super(VariableType, self).__init__(frozenset())
@@ -353,13 +353,20 @@ def changeVariance(old, new):
     assert new is not BIVARIANT
     if old is INVARIANT:
         return INVARIANT
-    elif old in [BIVARIANT, COVARIANT]:
+    elif old in [BIVARIANT, flags.COVARIANT]:
         return new
     else:
-        if new is CONTRAVARIANT:
-            return COVARIANT
-        elif new is COVARIANT:
-            return CONTRAVARIANT
+        if new is flags.CONTRAVARIANT:
+            return flags.COVARIANT
+        elif new is flags.COVARIANT:
+            return flags.CONTRAVARIANT
         else:
             assert new is INVARIANT
             return INVARIANT
+
+__all__ = ["BIVARIANT","INVARIANT", "UnitType", "BooleanType", "I8Type",
+           "I16Type", "I32Type", "I64Type", "F32Type", "F64Type",
+           "VariableType", "ClassType",  "NoType",
+           "getRootClassType", "getStringType", "getNullType",
+           "getClassFromType", "NULLABLE_TYPE_FLAG", "changeVariance",
+           "getNothingClassType"]

--- a/compiler/ir_types.py
+++ b/compiler/ir_types.py
@@ -12,6 +12,7 @@ from data import *
 from errors import *
 from flags import *
 from ir_values import *
+import utils
 
 NULLABLE_TYPE_FLAG = "nullable"
 
@@ -218,7 +219,7 @@ class ClassType(ObjectType):
         return "ClassType(%s%s%s)" % (self.clas.name, typeArgsStr, flagsStr)
 
     def __hash__(self):
-        return hashList([getattr(self, name) for name in Type.propertyNames] + \
+        return utils.hashList([getattr(self, name) for name in Type.propertyNames] + \
                         [self.clas.name, self.typeArguments])
 
     def __eq__(self, other):
@@ -288,7 +289,7 @@ class VariableType(ObjectType):
         return "VariableType(%s)" % self.typeParameter.name
 
     def __hash__(self):
-        return hashList([self.typeParameter.name])
+        return utils.hashList([self.typeParameter.name])
 
     def __eq__(self, other):
         return self.__class__ is other.__class__ and \

--- a/compiler/ir_values.py
+++ b/compiler/ir_values.py
@@ -4,11 +4,10 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from builtins import *
-from data import *
-from ir_types import *
+import data
+import ir_types
 
-class Value(Data):
+class Value(data.Data):
     propertyNames = ()
 
     def type(self):
@@ -17,58 +16,58 @@ class Value(Data):
 
 class UnitValue(Value):
     def type(self):
-        return UnitType
+        return ir_types.UnitType
 
 
 class BooleanValue(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return BooleanType
+        return ir_types.BooleanType
 
 
 class I8Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return I8Type
+        return ir_types.I8Type
 
 
 class I16Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return I16Type
+        return ir_types.I16Type
 
 
 class I32Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return I32Type
+        return ir_types.I32Type
 
 
 class I64Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return I64Type
+        return ir_types.I64Type
 
 
 class F32Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return F32Type
+        return ir_types.F32Type
 
 
 class F64Value(Value):
     propertyNames = Value.propertyNames + ("value",)
 
     def type(self):
-        return F64Type
+        return ir_types.F64Type
 
 
 class NullValue(Value):
     def type(self):
-        return getNullType()
+        return ir_types.getNullType()

--- a/compiler/layout.py
+++ b/compiler/layout.py
@@ -29,7 +29,7 @@
 
 import re
 
-from tok import *
+from tok import Token, SYMBOL, OPERATOR, NEWLINE, SPACE, COMMENT, INTERNAL
 
 def layout(tokensIn, skipAnalysis=False):
     if skipAnalysis:
@@ -233,3 +233,5 @@ class PatternManager(object):
 
     def match(self):
         return any(self.stack[-1])
+
+__all__ = ["layout"]

--- a/compiler/lexer.py
+++ b/compiler/lexer.py
@@ -6,8 +6,8 @@
 
 import re
 
-from errors import *
-from location import *
+from errors import LexException
+from location import Location
 from tok import *
 
 __opchars = r"[!#%&*+\-/:<=>?@\\^|~]"
@@ -118,3 +118,5 @@ def lex(filename, source):
         pos += len(token.text)
 
     return tokens
+
+__all__ = ["lex"]

--- a/compiler/location.py
+++ b/compiler/location.py
@@ -4,7 +4,7 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from data import *
+from data import Data
 
 class Location(Data):
     propertyNames = ["fileName", "beginRow", "beginColumn", "endRow", "endColumn"]
@@ -32,3 +32,5 @@ class Location(Data):
 
 
 NoLoc = Location("<unknown>", 1, 1, 1, 1)
+
+__all__ = ["Location", "NoLoc"]

--- a/compiler/scope_analysis.py
+++ b/compiler/scope_analysis.py
@@ -30,6 +30,7 @@ from ir_types import *
 from location import *
 from builtins import *
 from utils import *
+from bytecode import *
 
 def analyzeDeclarations(info):
     """Traverses the AST, creating a scope tree and DefnInfo for definition nodes.

--- a/compiler/scope_analysis.py
+++ b/compiler/scope_analysis.py
@@ -19,18 +19,18 @@
 # - convertClosures
 # - flattenClasses
 
-from ast import *
-from compile_info import *
-from data import *
-from errors import *
+import ast
+from compile_info import ContextInfo, ClosureInfo, DefnInfo, ClassInfo, UseInfo, getAllArgumentTypes, GLOBAL_SCOPE_ID, BUILTIN_SCOPE_ID, USE_AS_VALUE, USE_AS_TYPE, USE_AS_PROPERTY, USE_AS_CONSTRUCTOR, CONTEXT_CONSTRUCTOR_HINT, CLOSURE_CONSTRUCTOR_HINT, NOT_HERITABLE
+from data import Data
+from errors import TypeException, ScopeException
 from flags import *
-from graph import *
-from ir import *
-from ir_types import *
-from location import *
-from builtins import *
-from utils import *
-from bytecode import *
+from graph import Graph
+import ir
+from ir_types import getRootClassType, ClassType, UnitType
+from location import Location, NoLoc
+from builtins import registerBuiltins, isBuiltinId, getBuiltinClasses
+from utils import Counter
+from bytecode import BUILTIN_ROOT_CLASS_ID
 
 def analyzeDeclarations(info):
     """Traverses the AST, creating a scope tree and DefnInfo for definition nodes.
@@ -48,13 +48,13 @@ def analyzeDeclarations(info):
     info.setScope(GLOBAL_SCOPE_ID, info.globalScope)
 
     def createBuiltinInfo(name, irDefn):
-        if isinstance(irDefn, Class):
+        if isinstance(irDefn, ir.Class):
             # This scope will automatically be added to info.scopes.
             BuiltinScope(irDefn, info.globalScope)
             # DefnInfos for the class and its members are created by BuiltinScope.
             defnInfo = info.getDefnInfo(irDefn)
         else:
-            assert isinstance(irDefn, Function)
+            assert isinstance(irDefn, ir.Function)
             defnInfo = DefnInfo(irDefn, BUILTIN_SCOPE_ID)
             info.setDefnInfo(irDefn, defnInfo)
         info.globalScope.bind(name, defnInfo)
@@ -86,7 +86,7 @@ def analyzeInheritance(info):
 
     # Add edges for builtin classes. Still need to track these, even though they aren't in AST.
     def handleBuiltinInheritance(name, irDefn):
-        if isinstance(irDefn, Class):
+        if isinstance(irDefn, ir.Class):
             assert len(irDefn.supertypes) <= 1
             if len(irDefn.supertypes) == 1:
                 classInfo = info.getClassInfo(irDefn)
@@ -94,7 +94,7 @@ def analyzeInheritance(info):
                 classInfo.superclassInfo = info.getClassInfo(irSuperclass)
                 inheritanceGraph.addEdge(irDefn.id, irSuperclass.id)
                 subtypeGraph.addEdge(irDefn.id, irSuperclass.id)
-        elif isinstance(irDefn, TypeParameter):
+        elif isinstance(irDefn, ir.TypeParameter):
             raise NotImplementedError
     registerBuiltins(handleBuiltinInheritance)
 
@@ -266,18 +266,15 @@ def flattenClasses(info):
                                          (m.name, irClass.name))
 
 
-NOT_HERITABLE = -1
-
-
 def isHeritable(irDefn):
     """Returns true if the given irDefn can be inherited from a base class by a
     deriving class."""
-    if isinstance(irDefn, Function) and irDefn.name == "$constructor":
+    if isinstance(irDefn, ir.Function) and irDefn.name == "$constructor":
         # Constructors are not heritable. At this time when this function is called, the
         # function may not have been made into a method yet, so Function.isConstructor would
         # return false. So we check the name instead, which is a hack.
         return False
-    if isinstance(irDefn, TypeParameter):
+    if isinstance(irDefn, ir.TypeParameter):
         return False
     return True
 
@@ -299,8 +296,8 @@ class NameInfo(object):
         self.overloads.append(defnInfo)
 
     def isOverloadable(self, otherDefnInfo):
-        return isinstance(otherDefnInfo.irDefn, Function) and \
-               isinstance(self.overloads[0].irDefn, Function)
+        return isinstance(otherDefnInfo.irDefn, ir.Function) and \
+               isinstance(self.overloads[0].irDefn, ir.Function)
 
     def isOverloaded(self):
         return len(self.overloads) > 1
@@ -313,7 +310,7 @@ class NameInfo(object):
         return iter(self.overloads)
 
     def isClass(self):
-        return not self.isOverloaded() and isinstance(self.getDefnInfo().irDefn, Class)
+        return not self.isOverloaded() and isinstance(self.getDefnInfo().irDefn, ir.Class)
 
     def getInfoForConstructors(self, info):
         assert self.isClass()
@@ -366,7 +363,7 @@ class NameInfo(object):
 
                 aIrDefn = aDefnInfo.irDefn
                 bIrDefn = bDefnInfo.irDefn
-                assert isinstance(aIrDefn, Function) and isinstance(bIrDefn, Function)
+                assert isinstance(aIrDefn, ir.Function) and isinstance(bIrDefn, ir.Function)
                 if aIrDefn.mayOverride(bIrDefn):
                     # Check that nothing else is already overriding this function.
                     if bIrDefn.id in self.overrides:
@@ -405,21 +402,21 @@ class NameInfo(object):
         candidate = None
         for defnInfo in self.overloads:
             irDefn = defnInfo.irDefn
-            if isinstance(irDefn, Function) and irDefn.id in self.overrides:
+            if isinstance(irDefn, ir.Function) and irDefn.id in self.overrides:
                 continue
 
-            if not isinstance(irDefn, Function) and \
+            if not isinstance(irDefn, ir.Function) and \
                len(typeArgs) == 0 and len(argTypes) == 0:
                 # Non-function
                 typesAndArgs = (None, None)
                 match = True
             elif not receiverIsExplicit and \
-                 isinstance(irDefn, Function) and \
+                 isinstance(irDefn, ir.Function) and \
                  not irDefn.isMethod():
                 # Regular function
                 typesAndArgs = getAllArgumentTypes(irDefn, None, typeArgs, argTypes)
                 match = typesAndArgs is not None
-            elif isinstance(irDefn, Function) and \
+            elif isinstance(irDefn, ir.Function) and \
                  irDefn.isMethod():
                 # Method call
                 typesAndArgs = getAllArgumentTypes(irDefn, receiverType, typeArgs, argTypes)
@@ -439,7 +436,7 @@ class NameInfo(object):
         return candidate
 
 
-class Scope(AstNodeVisitor):
+class Scope(ast.AstNodeVisitor):
     def __init__(self, ast, scopeId, parent, info):
         self.scopeId = scopeId
         self.ast = ast
@@ -465,7 +462,7 @@ class Scope(AstNodeVisitor):
 
     def getAstDefn(self):
         scope = self.topLocalScope()
-        assert isinstance(scope.ast, AstDefinition)
+        assert isinstance(scope.ast, ast.AstDefinition)
         return scope.ast
 
     def getIrDefn(self):
@@ -534,19 +531,19 @@ class Scope(AstNodeVisitor):
         implicitTypeParams = self.getImplicitTypeParameters()
         flags = getFlagsFromAstDefn(astDefn, None)
         checkFlags(flags, frozenset([ABSTRACT]), astDefn.location)
-        irDefn = Class(astDefn.name, implicitTypeParams, None, None, [], [], [], flags)
+        irDefn = ir.Class(astDefn.name, implicitTypeParams, None, None, [], [], [], flags)
         self.info.package.addClass(irDefn)
 
-        irInitializer = Function("$initializer", list(implicitTypeParams),
-                                 [], None, [], None, frozenset())
+        irInitializer = ir.Function("$initializer", list(implicitTypeParams),
+                                    [], None, [], None, frozenset())
         irInitializer.astDefn = astDefn
         self.makeMethod(irInitializer, irDefn)
         self.info.package.addFunction(irInitializer)
         irDefn.initializer = irInitializer
 
         if not astDefn.hasConstructors():
-            irDefaultCtor = Function("$constructor", list(implicitTypeParams),
-                                     [], None, [], None, frozenset())
+            irDefaultCtor = ir.Function("$constructor", list(implicitTypeParams),
+                                        [], None, [], None, frozenset())
             irDefaultCtor.astDefn = astDefn
             self.makeMethod(irDefaultCtor, irDefn)
             self.info.package.addFunction(irDefaultCtor)
@@ -561,7 +558,7 @@ class Scope(AstNodeVisitor):
         Note that this does not add the function to the class's methods or constructors lists.
         """
         function.clas = clas
-        this = Variable("$this", None, PARAMETER, frozenset([LET]))
+        this = ir.Variable("$this", None, ir.PARAMETER, frozenset([LET]))
         function.variables.insert(0, this)
 
     def isDefinedAutomatically(self, astDefn):
@@ -636,8 +633,8 @@ class Scope(AstNodeVisitor):
 
     def isLocal(self):
         """Returns true if values defined in the parent scope are accessible in this scope."""
-        return isinstance(self.ast, AstBlockExpression) or \
-               isinstance(self.ast, AstPartialFunctionCase)
+        return isinstance(self.ast, ast.AstBlockExpression) or \
+               isinstance(self.ast, ast.AstPartialFunctionCase)
 
     def isLocalWithin(self, defnScope):
         """Returns true if values defined in defnScope may be accessed directly in this scope."""
@@ -716,7 +713,7 @@ class Scope(AstNodeVisitor):
             irClosureClass = closureInfo.irClosureClass
             irContextClass = self.info.getContextInfo(scopeId).irContextClass
             irContextType = ClassType(irContextClass)
-            irContextField = Field("$context", irContextType, frozenset())
+            irContextField = ir.Field("$context", irContextType, frozenset())
             irClosureClass.fields.append(irContextField)
             irClosureClass.constructors[0].parameterTypes.append(irContextType)
             closureInfo.irClosureContexts[scopeId] = irContextField
@@ -774,22 +771,22 @@ class GlobalScope(Scope):
 
     def createIrDefn(self, astDefn, astVarDefn):
         flags = getFlagsFromAstDefn(astDefn, astVarDefn)
-        if isinstance(astDefn, AstVariablePattern):
+        if isinstance(astDefn, ast.AstVariablePattern):
             checkFlags(flags, frozenset([LET]), astDefn.location)
-            irDefn = Global(astDefn.name, None, flags)
+            irDefn = ir.Global(astDefn.name, None, flags)
             self.info.package.addGlobal(irDefn)
-        elif isinstance(astDefn, AstFunctionDefinition):
+        elif isinstance(astDefn, ast.AstFunctionDefinition):
             checkFlags(flags, frozenset(), astDefn.location)
             if astDefn.body is None:
                 raise ScopeException(astDefn.location,
                                      "%s: global function must have body" % astDefn.name)
-            irDefn = Function(astDefn.name, None, self.getImplicitTypeParameters(),
-                              None, [], None, flags)
+            irDefn = ir.Function(astDefn.name, None, self.getImplicitTypeParameters(),
+                                 None, [], None, flags)
             self.info.package.addFunction(irDefn)
             if astDefn.name == "main":
                 assert self.info.package.entryFunction == -1
                 self.info.package.entryFunction = irDefn.id
-        elif isinstance(astDefn, AstClassDefinition):
+        elif isinstance(astDefn, ast.AstClassDefinition):
             irDefn = self.createIrClassDefn(astDefn)
         else:
             raise NotImplementedError
@@ -842,49 +839,49 @@ class FunctionScope(Scope):
     def createIrDefn(self, astDefn, astVarDefn):
         topScope = self.topLocalScope()
         irScopeDefn = self.info.getDefnInfo(topScope.scopeId).irDefn
-        if isinstance(irScopeDefn, Class):
+        if isinstance(irScopeDefn, ir.Class):
             irScopeDefn = irScopeDefn.initializer
-        assert isinstance(irScopeDefn, Function)
+        assert isinstance(irScopeDefn, ir.Function)
 
         flags = getFlagsFromAstDefn(astDefn, astVarDefn)
-        if isinstance(astDefn, AstTypeParameter):
+        if isinstance(astDefn, ast.AstTypeParameter):
             checkFlags(flags, frozenset([STATIC]), astDefn.location)
             if STATIC not in flags:
                 raise NotImplementedError
-            irDefn = TypeParameter(astDefn.name, None, None, flags)
+            irDefn = ir.TypeParameter(astDefn.name, None, None, flags)
             self.info.package.addTypeParameter(irDefn)
             irScopeDefn.typeParameters.append(irDefn)
-        elif isinstance(astDefn, AstParameter):
+        elif isinstance(astDefn, ast.AstParameter):
             checkFlags(flags, frozenset(), astDefn.location)
-            if isinstance(astDefn.pattern, AstVariablePattern):
+            if isinstance(astDefn.pattern, ast.AstVariablePattern):
                 # If the parameter is a simple variable which doesn't need unpacking, we don't
                 # need to create a separate definition here.
                 irDefn = None
             else:
-                irDefn = Variable("$parameter", None, PARAMETER, flags)
+                irDefn = ir.Variable("$parameter", None, ir.PARAMETER, flags)
                 irScopeDefn.variables.append(irDefn)
-        elif isinstance(astDefn, AstVariablePattern):
+        elif isinstance(astDefn, ast.AstVariablePattern):
             checkFlags(flags, frozenset([LET]), astDefn.location)
-            kind = PARAMETER if isinstance(astVarDefn, AstParameter) else LOCAL
-            irDefn = Variable(astDefn.name, None, kind, flags)
+            kind = ir.PARAMETER if isinstance(astVarDefn, ast.AstParameter) else ir.LOCAL
+            irDefn = ir.Variable(astDefn.name, None, kind, flags)
             irScopeDefn.variables.append(irDefn)
-        elif isinstance(astDefn, AstFunctionDefinition):
+        elif isinstance(astDefn, ast.AstFunctionDefinition):
             checkFlags(flags, frozenset(), astDefn.location)
             if astDefn.body is None:
                 raise ScopeException(astDefn.location,
                                      "%s: function must have body" % astDefn.name)
             implicitTypeParams = self.getImplicitTypeParameters()
-            irDefn = Function(astDefn.name, None, implicitTypeParams, None, [], None, flags)
+            irDefn = ir.Function(astDefn.name, None, implicitTypeParams, None, [], None, flags)
             self.info.package.addFunction(irDefn)
-        elif isinstance(astDefn, AstClassDefinition):
+        elif isinstance(astDefn, ast.AstClassDefinition):
             irDefn = self.createIrClassDefn(astDefn)
         else:
             raise NotImplementedError
         return irDefn
 
     def isDefinedAutomatically(self, astDefn):
-        return isinstance(astDefn, AstClassDefinition) or \
-               isinstance(astDefn, AstFunctionDefinition)
+        return isinstance(astDefn, ast.AstClassDefinition) or \
+               isinstance(astDefn, ast.AstFunctionDefinition)
 
     def findEnclosingClass(self):
         return self.parent.findEnclosingClass()
@@ -896,20 +893,20 @@ class FunctionScope(Scope):
 
         # Create the context class.
         implicitTypeParams = self.getImplicitTypeParameters()
-        irContextClass = Class("$context", list(implicitTypeParams), [getRootClassType()], None,
-                               [], [], [], frozenset())
+        irContextClass = ir.Class("$context", list(implicitTypeParams), [getRootClassType()], None,
+                                  [], [], [], frozenset())
         self.info.package.addClass(irContextClass)
         irContextType = ClassType(irContextClass, ())
-        ctor = Function("$contextCtor", UnitType, list(implicitTypeParams), [irContextType],
-                        [Variable("$this", irContextType, PARAMETER, frozenset([LET]))],
-                        [], frozenset())
+        ctor = ir.Function("$contextCtor", UnitType, list(implicitTypeParams), [irContextType],
+                           [ir.Variable("$this", irContextType, ir.PARAMETER, frozenset([LET]))],
+                           [], frozenset())
         ctor.compileHint = CONTEXT_CONSTRUCTOR_HINT
         self.info.package.addFunction(ctor)
         irContextClass.constructors.append(ctor)
         contextInfo.irContextClass = irContextClass
 
         # Create a variable to hold an instance of it.
-        irContextVar = Variable("$context", irContextType, LOCAL, frozenset())
+        irContextVar = ir.Variable("$context", irContextType, ir.LOCAL, frozenset())
         self.getIrDefn().variables.append(irContextVar)
         closureInfo = self.info.getClosureInfo(self.getAstDefn())
         closureInfo.irClosureContexts[self.scopeId] = irContextVar
@@ -917,22 +914,22 @@ class FunctionScope(Scope):
     def captureInContext(self, defnInfo, irContextClass):
         contextInfo = self.info.getContextInfo(self.scopeId)
         irDefn = defnInfo.irDefn
-        if isinstance(irDefn, Field):
+        if isinstance(irDefn, ir.Field):
             # variable which was already captured
             pass
-        elif isinstance(irDefn, Variable):
+        elif isinstance(irDefn, ir.Variable):
             defnInfo.irDefn.kind = None  # finish() will delete this
-            irCaptureField = Field(defnInfo.irDefn.name, irDefn.type, frozenset())
+            irCaptureField = ir.Field(defnInfo.irDefn.name, irDefn.type, frozenset())
             if hasattr(defnInfo.irDefn, "astDefn"):
                 irCaptureField.astDefn = defnInfo.irDefn.astDefn
             if hasattr(defnInfo.irDefn, "astVarDefn"):
                 irCaptureField.astVarDefn = defnInfo.irDefn.astVarDefn
             irContextClass.fields.append(irCaptureField)
             defnInfo.irDefn = irCaptureField
-        elif isinstance(defnInfo.irDefn, Function):
+        elif isinstance(defnInfo.irDefn, ir.Function):
             # TODO
             raise NotImplementedError
-        elif isinstance(defnInfo.irDefn, Class):
+        elif isinstance(defnInfo.irDefn, ir.Class):
             # TODO
             raise NotImplementedError
         else:
@@ -947,16 +944,16 @@ class FunctionScope(Scope):
 
         # Create a closure class to hold this method and its contexts.
         implicitTypeParams = self.getImplicitTypeParameters()
-        irClosureClass = Class("$closure", list(implicitTypeParams), [getRootClassType()], None,
-                               [], [], [], frozenset())
+        irClosureClass = ir.Class("$closure", list(implicitTypeParams), [getRootClassType()], None,
+                                  [], [], [], frozenset())
         self.info.package.addClass(irClosureClass)
         closureInfo.irClosureClass = irClosureClass
         irClosureType = ClassType(irClosureClass)
-        irClosureCtor = Function("$closureCtor", UnitType,
-                                 list(implicitTypeParams), [irClosureType],
-                                 [Variable("$this", irClosureType,
-                                           PARAMETER, frozenset([LET]))],
-                                 None, frozenset())
+        irClosureCtor = ir.Function("$closureCtor", UnitType,
+                                    list(implicitTypeParams), [irClosureType],
+                                    [ir.Variable("$this", irClosureType,
+                                                 ir.PARAMETER, frozenset([LET]))],
+                                    None, frozenset())
         irClosureCtor.clas = irClosureClass
         irClosureCtor.compileHint = CLOSURE_CONSTRUCTOR_HINT
         irClosureClass.constructors.append(irClosureCtor)
@@ -966,14 +963,14 @@ class FunctionScope(Scope):
         irDefn = self.getIrDefn()
         assert not irDefn.isMethod()
         irDefn.clas = irClosureClass
-        irDefn.variables.insert(0, Variable("$this", irClosureType,
-                                            PARAMETER, frozenset([LET])))
+        irDefn.variables.insert(0, ir.Variable("$this", irClosureType,
+                                               ir.PARAMETER, frozenset([LET])))
         irDefn.parameterTypes.insert(0, irClosureType)
         irClosureClass.methods.append(irDefn)
 
         # If the parent is a function scope, define a local variable to hold the closure.
         if isinstance(self.parent, FunctionScope):
-            irClosureVar = Variable(irDefn.name, irClosureType, LOCAL, frozenset())
+            irClosureVar = ir.Variable(irDefn.name, irClosureType, ir.LOCAL, frozenset())
             self.parent.getIrDefn().variables.append(irClosureVar)
             closureInfo.irClosureVar = irClosureVar
 
@@ -993,7 +990,7 @@ class FunctionScope(Scope):
             oldVariables = scopeIrDefn.variables
             scopeIrDefn.variables = []
             for var in oldVariables:
-                if var.kind is LOCAL:
+                if var.kind is ir.LOCAL:
                     var.id = nextLocalId()
                 if var.kind is not None:
                     # delete context variables
@@ -1022,11 +1019,11 @@ class ClassScope(Scope):
     def createIrDefn(self, astDefn, astVarDefn):
         irScopeDefn = self.getIrDefn()
         flags = getFlagsFromAstDefn(astDefn, astVarDefn)
-        if isinstance(astDefn, AstVariablePattern):
+        if isinstance(astDefn, ast.AstVariablePattern):
             checkFlags(flags, frozenset([LET, PROTECTED, PRIVATE]), astDefn.location)
-            irDefn = Field(astDefn.name, None, flags, id=len(irScopeDefn.fields,))
+            irDefn = ir.Field(astDefn.name, None, flags, id=len(irScopeDefn.fields,))
             irScopeDefn.fields.append(irDefn)
-        elif isinstance(astDefn, AstFunctionDefinition):
+        elif isinstance(astDefn, ast.AstFunctionDefinition):
             implicitTypeParams = self.getImplicitTypeParameters()
             if ABSTRACT in flags and astDefn.body is not None:
                 raise ScopeException(astDefn.location,
@@ -1040,48 +1037,48 @@ class ClassScope(Scope):
                                      astDefn.name)
             if astDefn.name == "this":
                 checkFlags(flags, frozenset([PROTECTED, PRIVATE]), astDefn.location)
-                irDefn = Function("$constructor", None, implicitTypeParams,
-                                  None, [], None, flags)
+                irDefn = ir.Function("$constructor", None, implicitTypeParams,
+                                     None, [], None, flags)
                 irScopeDefn.constructors.append(irDefn)
             else:
                 checkFlags(flags, frozenset([ABSTRACT, PROTECTED, PRIVATE]), astDefn.location)
-                irDefn = Function(astDefn.name, None, implicitTypeParams,
-                                  None, [], None, flags)
+                irDefn = ir.Function(astDefn.name, None, implicitTypeParams,
+                                     None, [], None, flags)
                 irScopeDefn.methods.append(irDefn)
             # We don't need to call makeMethod here because the inner FunctionScope will do it.
             self.info.package.addFunction(irDefn)
-        elif isinstance(astDefn, AstPrimaryConstructorDefinition):
+        elif isinstance(astDefn, ast.AstPrimaryConstructorDefinition):
             checkFlags(flags, frozenset([PROTECTED, PRIVATE]), astDefn.location)
             implicitTypeParams = self.getImplicitTypeParameters()
-            irDefn = Function("$constructor", None, implicitTypeParams, None, [], None, flags)
+            irDefn = ir.Function("$constructor", None, implicitTypeParams, None, [], None, flags)
             irScopeDefn.constructors.append(irDefn)
             self.makeMethod(irDefn, irScopeDefn)
             self.info.package.addFunction(irDefn)
-        elif isinstance(astDefn, AstTypeParameter):
+        elif isinstance(astDefn, ast.AstTypeParameter):
             checkFlags(flags, frozenset([STATIC, COVARIANT, CONTRAVARIANT]), astDefn.location)
             if STATIC not in flags:
                 raise NotImplementedError
-            irDefn = TypeParameter(astDefn.name, None, None, flags, clas=irScopeDefn)
+            irDefn = ir.TypeParameter(astDefn.name, None, None, flags, clas=irScopeDefn)
             self.info.package.addTypeParameter(irDefn)
             irScopeDefn.typeParameters.append(irDefn)
             irScopeDefn.initializer.typeParameters.append(irDefn)
             for ctor in irScopeDefn.constructors:
                 ctor.typeParameters.append(irDefn)
-        elif isinstance(astDefn, AstParameter):
+        elif isinstance(astDefn, ast.AstParameter):
             # Parameters in a class scope can only belong to a primary constructor. They are
             # never treated as local variables, so we don't need to create definitions here.
             irDefn = None
         else:
-            assert isinstance(astDefn, AstClassDefinition)
+            assert isinstance(astDefn, ast.AstClassDefinition)
             irDefn = self.createIrClassDefn(astDefn)
         return irDefn
 
     def isDefinedAutomatically(self, astDefn):
-        return isinstance(astDefn, AstPrimaryConstructorDefinition) or \
-               isinstance(astDefn, AstFunctionDefinition) or \
-               isinstance(astDefn, AstClassDefinition) or \
-               isinstance(astDefn, AstVariableDefinition) or \
-               isinstance(astDefn, AstVariablePattern)
+        return isinstance(astDefn, ast.AstPrimaryConstructorDefinition) or \
+               isinstance(astDefn, ast.AstFunctionDefinition) or \
+               isinstance(astDefn, ast.AstClassDefinition) or \
+               isinstance(astDefn, ast.AstVariableDefinition) or \
+               isinstance(astDefn, ast.AstVariablePattern)
 
     def findEnclosingClass(self):
         return self.getIrDefn()
@@ -1137,7 +1134,7 @@ class BuiltinScope(Scope):
             self.define(field.name)
 
 
-class ScopeVisitor(AstNodeVisitor):
+class ScopeVisitor(ast.AstNodeVisitor):
     """Abstract base class for scope analysis related visitor.
 
     This class takes care of the common tasks of entering lexical scopes in the AST. visit
@@ -1175,7 +1172,7 @@ class ScopeVisitor(AstNodeVisitor):
         self.visit(node.pattern, node)
 
     def visitAstBlockExpression(self, node):
-        if isinstance(self.scope.ast, AstFunctionDefinition) and \
+        if isinstance(self.scope.ast, ast.AstFunctionDefinition) and \
            self.scope.ast.body is node:
             self.visitChildren(node)
         else:
@@ -1248,7 +1245,7 @@ class InheritanceVisitor(ScopeVisitor):
         else:
             supertype = node.supertype
             supertypeIrDefn = self.addTypeToSubtypeGraph(irClass.id, scope, supertype)
-            if not isinstance(supertypeIrDefn, Class):
+            if not isinstance(supertypeIrDefn, ir.Class):
                 raise ScopeException(node.location, "inheritance from non-class type")
 
             superclassId = supertypeIrDefn.id
@@ -1272,7 +1269,7 @@ class InheritanceVisitor(ScopeVisitor):
             self.addTypeToSubtypeGraph(irParam.id, self.scope, node.lowerBound)
 
     def addTypeToSubtypeGraph(self, id, scope, astType):
-        if not isinstance(astType, AstClassType):
+        if not isinstance(astType, ast.AstClassType):
             raise ScopeException(astType.location, "inheritance from non-class type")
         nameInfo = scope.lookup(astType.name, astType.location, ignoreDefnOrder=True)
         if nameInfo.isOverloaded():
@@ -1288,19 +1285,19 @@ class InheritanceVisitor(ScopeVisitor):
 
 def getFlagsFromAstDefn(astDefn, astVarDefn):
     flags = set()
-    if isinstance(astDefn, AstDefinition):
+    if isinstance(astDefn, ast.AstDefinition):
         attribs = astDefn.attribs
-    elif isinstance(astVarDefn, AstDefinition):
+    elif isinstance(astVarDefn, ast.AstDefinition):
         attribs = astVarDefn.attribs
     else:
         attribs = []
 
-    if isinstance(astDefn, AstVariablePattern) and \
-       not ((isinstance(astVarDefn, AstVariableDefinition) and astVarDefn.keyword == "var") or \
-            (isinstance(astVarDefn, AstParameter) and astVarDefn.var == "var")):
+    if isinstance(astDefn, ast.AstVariablePattern) and \
+       not ((isinstance(astVarDefn, ast.AstVariableDefinition) and astVarDefn.keyword == "var") or \
+            (isinstance(astVarDefn, ast.AstParameter) and astVarDefn.var == "var")):
         flags.add(LET)
 
-    if isinstance(astDefn, AstTypeParameter):
+    if isinstance(astDefn, ast.AstTypeParameter):
         if astDefn.variance == "+":
             flags.add(COVARIANT)
         elif astDefn.variance == "-":
@@ -1325,3 +1322,6 @@ def checkFlags(flags, mask, loc):
 
 def isInternalName(name):
     return name.startswith("$")
+
+__all__ = ["analyzeDeclarations","analyzeInheritance", "convertClosures",
+           "flattenClasses"]

--- a/compiler/test_closure_conversion.py
+++ b/compiler/test_closure_conversion.py
@@ -7,7 +7,7 @@
 import unittest
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from ast import *
 from scope_analysis import *

--- a/compiler/test_closure_conversion.py
+++ b/compiler/test_closure_conversion.py
@@ -13,6 +13,10 @@ from ast import *
 from scope_analysis import *
 from type_analysis import *
 from ir import *
+from compile_info import CompileInfo
+from ir_types import *
+from errors import *
+from builtins import *
 
 
 class TestClosureConversion(unittest.TestCase):

--- a/compiler/test_combinators.py
+++ b/compiler/test_combinators.py
@@ -6,7 +6,8 @@
 
 import unittest
 
-from combinators import *
+execfile("combinators.py")
+
 from tok import *
 from lexer import *
 

--- a/compiler/test_compiler.py
+++ b/compiler/test_compiler.py
@@ -20,7 +20,10 @@ from ir_types import *
 import ir_instructions
 from ir_instructions import *
 from bytecode import *
-
+from flags import LET
+from compile_info import CompileInfo
+from builtins import *
+from errors import *
 
 class TestCompiler(unittest.TestCase):
     def compileFromSource(self, source):

--- a/compiler/test_compiler.py
+++ b/compiler/test_compiler.py
@@ -8,7 +8,7 @@ import unittest
 import sys
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from ast import *
 from compile_info import *

--- a/compiler/test_declaration_analysis.py
+++ b/compiler/test_declaration_analysis.py
@@ -13,6 +13,8 @@ from ast import *
 from compile_info import *
 from scope_analysis import *
 from ir import *
+from errors import *
+from flags import *
 
 class TestDeclarations(unittest.TestCase):
     def parseFromSource(self, source):

--- a/compiler/test_declaration_analysis.py
+++ b/compiler/test_declaration_analysis.py
@@ -7,7 +7,7 @@
 import unittest
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from ast import *
 from compile_info import *

--- a/compiler/test_flatten_classes.py
+++ b/compiler/test_flatten_classes.py
@@ -14,7 +14,8 @@ from scope_analysis import *
 from type_analysis import *
 from ir import *
 from builtins import *
-
+from compile_info import CompileInfo
+from errors import *
 
 class TestFlattenClasses(unittest.TestCase):
     def setUp(self):

--- a/compiler/test_flatten_classes.py
+++ b/compiler/test_flatten_classes.py
@@ -7,7 +7,7 @@
 import unittest
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from ast import *
 from scope_analysis import *

--- a/compiler/test_inheritance_analysis.py
+++ b/compiler/test_inheritance_analysis.py
@@ -9,10 +9,14 @@ import unittest
 from ast import *
 from compile_info import *
 from ir import *
+from ir_types import *
+from errors import *
 from layout import layout
 from lexer import *
 from parser import *
 from scope_analysis import *
+from builtins import getRootClass, getExceptionClass
+from bytecode import BUILTIN_ROOT_CLASS_ID
 
 class TestInheritanceAnalysis(unittest.TestCase):
     def parseFromSource(self, source):

--- a/compiler/test_inheritance_analysis.py
+++ b/compiler/test_inheritance_analysis.py
@@ -9,7 +9,7 @@ import unittest
 from ast import *
 from compile_info import *
 from ir import *
-from layout import *
+from layout import layout
 from lexer import *
 from parser import *
 from scope_analysis import *

--- a/compiler/test_ir.py
+++ b/compiler/test_ir.py
@@ -6,8 +6,9 @@
 
 import unittest
 
+execfile("ir.py")
+
 from builtins import *
-from ir import *
 from ir_types import *
 
 

--- a/compiler/test_ir_types.py
+++ b/compiler/test_ir_types.py
@@ -9,6 +9,7 @@ import unittest
 from builtins import *
 from ir import *
 from ir_types import *
+from ir import * # Needed for Class()
 from location import *
 from utils import *
 

--- a/compiler/test_ir_types.py
+++ b/compiler/test_ir_types.py
@@ -11,7 +11,9 @@ from ir import *
 from ir_types import *
 from ir import * # Needed for Class()
 from location import *
+from errors import * #For TypeException
 from utils import *
+from flags import * # For CONTRAVARIANT and COVARIANT
 
 
 class TestIrTypes(unittest.TestCase):

--- a/compiler/test_layout.py
+++ b/compiler/test_layout.py
@@ -7,7 +7,7 @@
 import unittest
 
 from lexer import *
-from layout import *
+from layout import layout
 
 class TestLayout(unittest.TestCase):
     def checkLayout(self, expectedTexts, text):

--- a/compiler/test_lexer.py
+++ b/compiler/test_lexer.py
@@ -7,6 +7,8 @@
 import unittest
 
 from lexer import *
+from errors import LexException
+from location import Location
 from tok import *
 
 class TestLexer(unittest.TestCase):

--- a/compiler/test_parser.py
+++ b/compiler/test_parser.py
@@ -11,6 +11,7 @@ from errors import *
 from parser import *
 from layout import layout
 from lexer import *
+from location import Location
 from combinators import *
 
 

--- a/compiler/test_parser.py
+++ b/compiler/test_parser.py
@@ -6,9 +6,11 @@
 
 import unittest
 
+execfile("parser.py")
+
+
 import ast
 from errors import *
-from parser import *
 from layout import layout
 from lexer import *
 from location import Location

--- a/compiler/test_parser.py
+++ b/compiler/test_parser.py
@@ -9,7 +9,7 @@ import unittest
 import ast
 from errors import *
 from parser import *
-from layout import *
+from layout import layout
 from lexer import *
 from combinators import *
 

--- a/compiler/test_type_analysis.py
+++ b/compiler/test_type_analysis.py
@@ -11,7 +11,7 @@ from compile_info import *
 from errors import *
 from ir import *
 from ir_types import *
-from layout import *
+from layout import layout
 from lexer import *
 from parser import *
 from scope_analysis import *

--- a/compiler/test_type_analysis.py
+++ b/compiler/test_type_analysis.py
@@ -16,7 +16,8 @@ from lexer import *
 from parser import *
 from scope_analysis import *
 from type_analysis import *
-
+from flags import *
+from builtins import getRootClass, getStringClass, getNothingClass, getExceptionClass
 
 class TestTypeAnalysis(unittest.TestCase):
     def analyzeFromSource(self, source):

--- a/compiler/test_use_analysis.py
+++ b/compiler/test_use_analysis.py
@@ -7,7 +7,7 @@
 import unittest
 
 from lexer import *
-from layout import *
+from layout import layout
 from parser import *
 from ast import *
 from scope_analysis import *

--- a/compiler/test_use_analysis.py
+++ b/compiler/test_use_analysis.py
@@ -13,6 +13,10 @@ from ast import *
 from scope_analysis import *
 from type_analysis import *
 from ir import *
+from compile_info import *
+from location import NoLoc
+from flags import LET
+from errors import *
 
 
 class TestUseAnalysis(unittest.TestCase):

--- a/compiler/tok.py
+++ b/compiler/tok.py
@@ -4,7 +4,7 @@
 # the GPL license that can be found in the LICENSE.txt file.
 
 
-from data import *
+from data import Data
 
 
 RESERVED = "reserved"
@@ -29,3 +29,7 @@ class Token(Data):
 
     def isPrintable(self):
         return self.tag not in [NEWLINE, SPACE, COMMENT]
+
+__all__ = ["Token", "RESERVED", "ATTRIB", "SYMBOL", "OPERATOR",
+           "INTEGER", "FLOAT", "STRING", "NEWLINE", "SPACE",
+           "COMMENT", "INTERNAL"]

--- a/compiler/type_analysis.py
+++ b/compiler/type_analysis.py
@@ -10,6 +10,9 @@ from scope_analysis import *
 from ir import *
 from ir_types import *
 from builtins import *
+from utils import COMPILE_FOR_VALUE, COMPILE_FOR_MATCH
+from compile_info import USE_AS_VALUE, USE_AS_TYPE, USE_AS_PROPERTY, USE_AS_CONSTRUCTOR, CallInfo, getExplicitTypeParameters, getImplicitTypeParameters
+from flags import COVARIANT, CONTRAVARIANT
 
 
 def analyzeTypes(info):

--- a/compiler/utils.py
+++ b/compiler/utils.py
@@ -150,3 +150,8 @@ COMPILE_FOR_VALUE = "compile-for-value"
 COMPILE_FOR_EFFECT = "compile-for-effect"
 COMPILE_FOR_MATCH = "compile-for-match"
 COMPILE_FOR_UNINITIALIZED = "compile-for-uninitialized"
+
+
+__all__ = ["encodeString", "tryDecodeString", "Counter", "hashList",
+           "COMPILE_FOR_VALUE", "COMPILE_FOR_EFFECT", "COMPILE_FOR_MATCH",
+           "COMPILE_FOR_UNINITIALIZED"]

--- a/compiler/visitor.py
+++ b/compiler/visitor.py
@@ -32,3 +32,5 @@ class Visitor(object):
 
     def handleResult(self, obj, result, *args):
         return result
+
+__all__ = ["Visitor"]


### PR DESCRIPTION
Another round for this pull request. This time, with compiler.py converted to use the "from X import A, B, C" style, and rebased on top of the recent changes.
