### PR TITLE
Import missing global variables

### DIFF
--- a/compiler/compiler
+++ b/compiler/compiler
@@ -14,6 +14,7 @@ import re
 import sys
 
 import ast
+from tok import NEWLINE, SPACE, COMMENT
 from location import NoLoc
 from ids import AstId, TARGET_PACKAGE_ID
 from ir import Package, PackageVersion, PackageDependency, Name


### PR DESCRIPTION
When running `compiler` with the `--no-layout` flag as in [0], we get a "NameError: global name 'X' not defined" error in line 84:

`layoutTokens = filter(lambda tok: tok.tag not in [NEWLINE, SPACE, COMMENT], rawTokens)`

Fixed by importing the three missing global variables declared in `tok.py`.

[0]: `python compiler ../examples/box.gy --no-std --no-layout`
